### PR TITLE
`AUHORIZATION` header name typo

### DIFF
--- a/src/digits-response.js
+++ b/src/digits-response.js
@@ -3,7 +3,7 @@
 
   function DigitsResponse () {
     var HEADER = {
-      AUHORIZATION: 'X-Verify-Credentials-Authorization',
+      AUTHORIZATION: 'X-Verify-Credentials-Authorization',
       URL: 'X-Auth-Service-Provider'
     };
 


### PR DESCRIPTION
This typo is causing the authorization to be returned as `undefined`.
